### PR TITLE
Add smooth transitions and GitHub Pages workflow

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,17 @@
+name: Deploy GitHub Pages
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/configure-pages@v3
+      - uses: actions/upload-pages-artifact@v1
+        with:
+          path: '.'
+      - uses: actions/deploy-pages@v1
+        id: deployment

--- a/README.md
+++ b/README.md
@@ -3,3 +3,16 @@
 This repository hosts the slide deck for the GitHub Pages site.
 
 Open `deck/index.html` to view the first slide. The remaining slides are available as `slide2.html` through `slide8.html` inside the `deck` folder.
+
+## GitHub Pages Deployment
+
+The repository includes a workflow in `.github/workflows/pages.yml` that uploads
+the deck as an artifact and deploys it using the official **Deploy to GitHub
+Pages** action. Pushes to the `main` branch will automatically update the live
+site.
+
+## Styling Guidelines
+
+Common styles are centralized in `deck/base.css`. Each slide links to this file
+and keeps slide-specific rules minimal. Smooth page transitions are handled by
+`deck/base.js` which fades between slides.

--- a/deck/base.css
+++ b/deck/base.css
@@ -9,6 +9,16 @@ body {
   justify-content: center;
   font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
   background: linear-gradient(135deg, #f8fafc 0%, #ffffff 100%);
+  opacity: 0;
+  transition: opacity 0.3s ease-in-out;
+}
+
+body.loaded {
+  opacity: 1;
+}
+
+body.fade-out {
+  opacity: 0;
 }
 
 .slide-container {

--- a/deck/base.js
+++ b/deck/base.js
@@ -1,0 +1,15 @@
+document.addEventListener('DOMContentLoaded', () => {
+  document.body.classList.add('loaded');
+  document.querySelectorAll('a[href]').forEach(anchor => {
+    const href = anchor.getAttribute('href');
+    if (!href.startsWith('#')) {
+      anchor.addEventListener('click', event => {
+        event.preventDefault();
+        document.body.classList.add('fade-out');
+        setTimeout(() => {
+          window.location.href = anchor.href;
+        }, 300);
+      });
+    }
+  });
+});

--- a/deck/index.html
+++ b/deck/index.html
@@ -168,6 +168,9 @@
       <svg class="logo-watermark" viewBox="0 0 2011 1566" xmlns="http://www.w3.org/2000/svg">
         <path d="M2011 1566L1201 173L506 1391L301 1390L1105 0L900 2L0 1563L605 1561L1205 527L1710 1392L1503 1389L1204 869L1105 1045L1405 1562L2011 1566Z" fill="#6b7280"/>
       </svg>
+      <div class="absolute bottom-4 right-4 flex space-x-4">
+        <a href="slide2.html" class="text-gray-600 hover:text-gray-900 text-xl"><i class="fas fa-arrow-right"></i></a>
+      </div>
     </div>
   </body>
 </html>

--- a/deck/index.html
+++ b/deck/index.html
@@ -6,6 +6,7 @@
     <script src="https://d3js.org/d3.v7.min.js"></script>
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css" rel="stylesheet">
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <script src="base.js"></script>
     <style>
       .slide-container {
         width: 1280px; 

--- a/deck/slide2.html
+++ b/deck/slide2.html
@@ -6,6 +6,7 @@
     <script src="https://d3js.org/d3.v7.min.js"></script>
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css" rel="stylesheet">
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <script src="base.js"></script>
     <style>
       .slide-container {
         width: 1280px; 

--- a/deck/slide3.html
+++ b/deck/slide3.html
@@ -6,6 +6,7 @@
     <script src="https://d3js.org/d3.v7.min.js"></script>
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css" rel="stylesheet">
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <script src="base.js"></script>
     <style>
       .slide-container {
         width: 1280px; 

--- a/deck/slide4.html
+++ b/deck/slide4.html
@@ -6,6 +6,7 @@
     <script src="https://d3js.org/d3.v7.min.js"></script>
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css" rel="stylesheet">
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <script src="base.js"></script>
     <style>
       .slide-container {
         width: 1280px; 

--- a/deck/slide5.html
+++ b/deck/slide5.html
@@ -6,6 +6,7 @@
     <script src="https://d3js.org/d3.v7.min.js"></script>
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css" rel="stylesheet">
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <script src="base.js"></script>
     <style>
       .slide-container {
         width: 1280px; 

--- a/deck/slide6.html
+++ b/deck/slide6.html
@@ -6,6 +6,7 @@
     <script src="https://d3js.org/d3.v7.min.js"></script>
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css" rel="stylesheet">
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <script src="base.js"></script>
     <style>
       .slide-container {
         width: 1280px; 

--- a/deck/slide7.html
+++ b/deck/slide7.html
@@ -6,6 +6,7 @@
     <script src="https://d3js.org/d3.v7.min.js"></script>
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css" rel="stylesheet">
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <script src="base.js"></script>
     <style>
       .slide-container {
         width: 1280px; 

--- a/deck/slide8.html
+++ b/deck/slide8.html
@@ -248,6 +248,7 @@
       </svg>
       <div class="absolute bottom-4 right-4 flex space-x-4">
         <a href="slide7.html" class="text-gray-600 hover:text-gray-900 text-xl"><i class="fas fa-arrow-left"></i></a>
+        <a href="index.html" class="text-gray-600 hover:text-gray-900 text-xl"><i class="fas fa-arrow-right"></i></a>
       </div>
     </div>
   </body>

--- a/deck/slide8.html
+++ b/deck/slide8.html
@@ -6,6 +6,7 @@
     <script src="https://d3js.org/d3.v7.min.js"></script>
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css" rel="stylesheet">
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <script src="base.js"></script>
     <style>
       .slide-container {
         width: 1280px; 


### PR DESCRIPTION
## Summary
- add fade animation rules in `deck/base.css`
- share JS logic in new `deck/base.js`
- link `base.js` in all slides
- document styling and deployment guidelines in README
- add CI workflow for GitHub Pages deployment

## Testing
- `curl -I https://validator.w3.org/nu/` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68493da1d50c8324afd0d7b18443a97a