### PR TITLE
Add HTML validation to workflow

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -9,8 +9,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Validate HTML
+        run: npx --yes html-validate index.html deck/*.html
       - uses: actions/configure-pages@v3
-      - uses: actions/upload-pages-artifact@v1
+      - uses: actions/upload-pages-artifact@v3
         with:
           path: '.'
       - uses: actions/deploy-pages@v1

--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ Open `deck/index.html` to view the first slide. The remaining slides are availab
 ## GitHub Pages Deployment
 
 The repository includes a workflow in `.github/workflows/pages.yml` that uploads
-the deck as an artifact and deploys it using the official **Deploy to GitHub
-Pages** action. Pushes to the `main` branch will automatically update the live
-site.
+the deck as an artifact and deploys it using the official **Deploy to GitHub Pages** action.
+A validation step runs `html-validate` on every HTML file to catch markup issues before deployment.
+Pushes to the `main` branch will automatically update the live site.
 
 ## Styling Guidelines
 


### PR DESCRIPTION
## Summary
- validate markup with html-validate during CI
- use newer `actions/upload-pages-artifact@v3`
- document HTML validation in README

## Testing
- `npx --yes html-validate index.html deck/*.html >/tmp/validate.log && tail -n 5 /tmp/validate.log`

------
https://chatgpt.com/codex/tasks/task_e_684940cfe4048324895482c9e6b41b56