### PR TITLE
Improve product stack table look

### DIFF
--- a/resources/stack-table.html
+++ b/resources/stack-table.html
@@ -3,164 +3,40 @@
 <head>
   <meta charset="UTF-8">
   <title>Product Stack Comparison</title>
-  <style>
-    body {
-      font-family: Arial, sans-serif;
-      margin: 40px;
-    }
-
-    .table-wrapper {
-      overflow-x: auto;
-    }
-
-    #stack-table {
-      border-collapse: collapse;
-      width: 100%;
-      min-width: 700px;
-    }
-
-    #stack-table th,
-    #stack-table td {
-      border: 1px solid #ccc;
-      padding: 6px 8px;
-      text-align: center;
-    }
-
-    #stack-table thead th {
-      background: #f0f0f0;
-      position: sticky;
-      top: 0;
-      z-index: 1;
-    }
-
-    #stack-table tbody tr:nth-child(even) {
-      background: #f9f9f9;
-    }
-
-    #stack-table .section-header th {
-      text-align: left;
-      background: #e5e7eb;
-    }
-
-    .coverage-full,
-    .coverage-partial,
-    .coverage-none,
-    .fit-complement,
-    .fit-incremental,
-    .fit-replace,
-    .fit-unnecessary {
-      padding: 2px 6px;
-      border-radius: 3px;
-      font-weight: 600;
-      display: inline-block;
-      margin: 2px 0;
-    }
-
-    .coverage-full {
-      background: #d1fae5;
-      color: #065f46;
-    }
-
-    .coverage-partial {
-      background: #fef3c7;
-      color: #92400e;
-    }
-
-    .coverage-none {
-      background: #fee2e2;
-      color: #7f1d1d;
-    }
-
-    .fit-complement {
-      background: #d1fae5;
-      color: #065f46;
-    }
-
-    .fit-incremental {
-      background: #fef3c7;
-      color: #92400e;
-    }
-
-    .fit-replace {
-      background: #fee2e2;
-      color: #7f1d1d;
-    }
-
-    .fit-unnecessary {
-      background: #e5e7eb;
-      color: #374151;
-    }
-
-    .legend {
-      margin-bottom: 1em;
-    }
-
-    .legend span {
-      margin-left: 0.5em;
-    }
-
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="stylesheet" href="https://cdn.datatables.net/1.13.4/css/jquery.dataTables.min.css">
+  <script src="https://code.jquery.com/jquery-3.5.1.min.js"></script>
+  <script src="https://cdn.datatables.net/1.13.4/js/jquery.dataTables.min.js"></script>
+  <style type="text/tailwindcss">
+    body {@apply p-10 font-sans;}
+    .table-wrapper {@apply overflow-x-auto;}
+    #stack-table {@apply border-collapse w-full min-w-[700px];}
+    #stack-table th, #stack-table td {@apply border border-gray-300 p-2 text-center;}
+    #stack-table thead th {@apply bg-gray-100 sticky top-0 z-10;}
+    #stack-table tbody tr:nth-child(even) {@apply bg-gray-50;}
+    #stack-table .section-header th {@apply text-left bg-gray-200;}
+    .coverage-full {@apply bg-green-100 text-green-700 font-semibold rounded px-2 inline-block;}
+    .coverage-partial {@apply bg-yellow-100 text-yellow-700 font-semibold rounded px-2 inline-block;}
+    .coverage-none {@apply bg-red-100 text-red-700 font-semibold rounded px-2 inline-block;}
+    .fit-complement {@apply bg-green-100 text-green-700 font-semibold rounded px-2 inline-block;}
+    .fit-incremental {@apply bg-yellow-100 text-yellow-700 font-semibold rounded px-2 inline-block;}
+    .fit-replace {@apply bg-red-100 text-red-700 font-semibold rounded px-2 inline-block;}
+    .fit-unnecessary {@apply bg-gray-300 text-gray-700 font-semibold rounded px-2 inline-block;}
+    .legend {@apply mb-4;}
+    .legend span {@apply ml-2;}
     @media (prefers-color-scheme: dark) {
-      body {
-        background: #1f2937;
-        color: #f1f5f9;
-      }
-
-      #stack-table {
-        border-color: #555;
-      }
-
-      #stack-table th,
-      #stack-table td {
-        border-color: #555;
-      }
-
-      #stack-table thead th {
-        background: #374151;
-        color: #f1f5f9;
-      }
-
-      #stack-table tbody tr:nth-child(even) {
-        background: #2b303b;
-      }
-
-      #stack-table .section-header th {
-        background: #4b5563;
-      }
-
-      .coverage-full {
-        background: #065f46;
-        color: #d1fae5;
-      }
-
-      .coverage-partial {
-        background: #92400e;
-        color: #fef3c7;
-      }
-
-      .coverage-none {
-        background: #7f1d1d;
-        color: #fee2e2;
-      }
-
-      .fit-complement {
-        background: #065f46;
-        color: #d1fae5;
-      }
-
-      .fit-incremental {
-        background: #92400e;
-        color: #fef3c7;
-      }
-
-      .fit-replace {
-        background: #7f1d1d;
-        color: #fee2e2;
-      }
-
-      .fit-unnecessary {
-        background: #374151;
-        color: #e5e7eb;
-      }
+      body {@apply bg-slate-800 text-slate-100;}
+      #stack-table th, #stack-table td {@apply border-gray-600;}
+      #stack-table thead th {@apply bg-slate-700 text-slate-100;}
+      #stack-table tbody tr:nth-child(even) {@apply bg-slate-700;}
+      #stack-table .section-header th {@apply bg-slate-600;}
+      .coverage-full {@apply bg-green-700 text-green-100;}
+      .coverage-partial {@apply bg-yellow-700 text-yellow-100;}
+      .coverage-none {@apply bg-red-700 text-red-100;}
+      .fit-complement {@apply bg-green-700 text-green-100;}
+      .fit-incremental {@apply bg-yellow-700 text-yellow-100;}
+      .fit-replace {@apply bg-red-700 text-red-100;}
+      .fit-unnecessary {@apply bg-gray-700 text-gray-200;}
     }
   </style>
 </head>
@@ -397,6 +273,11 @@
 </div>
 <script>
   document.addEventListener('DOMContentLoaded', () => {
+    $('#stack-table').DataTable({
+      paging: false,
+      info: false,
+      ordering: false
+    });
     const order = {
       'Complementary': 1,
       'Incremental': 2,


### PR DESCRIPTION
## Summary
- switch to Tailwind CSS for layout and colors
- add DataTables via CDN for filtering capability
- keep custom sort logic using Sales Strategy Fit

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684aa60d21248324b43d1423f69dc79f