### PR TITLE
Fix resource page opacity

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,15 +3,13 @@
 <head>
   <meta charset="UTF-8">
   <title>Above Resources</title>
-  <link href="deck/base.css" rel="stylesheet">
   <style>
     body {
-      font-family: 'Square Sans Text', 'Square Sans Display', -apple-system, BlinkMacSystemFont, sans-serif;
+      font-family: Arial, sans-serif;
       display: flex;
       flex-direction: column;
       align-items: center;
       padding: 40px;
-      background: linear-gradient(135deg, var(--above-gray-05) 0%, #ffffff 100%);
     }
     nav a {
       display: block;

--- a/resources/stack-table.html
+++ b/resources/stack-table.html
@@ -3,7 +3,6 @@
 <head>
   <meta charset="utf-8" />
   <title>Capability Explorer</title>
-  <link href="../deck/base.css" rel="stylesheet">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
   <link href="https://unpkg.com/tabulator-tables@5.5.2/dist/css/tabulator.min.css" rel="stylesheet">
@@ -12,15 +11,19 @@
   <style>
     html, body {
       margin: 0;
-      background-color: var(--above-gray-05);
-      font-family: 'Square Sans Text', 'Square Sans Display', -apple-system, BlinkMacSystemFont, sans-serif;
+      background-color: #f9fafb;
+      font-family: ui-sans-serif, system-ui, sans-serif;
     }
     .tabulator-row.tabulator-selected {
-      background-color: var(--above-blue) !important;
+      background-color: #2563eb !important;
       color: white !important;
     }
     .tabulator .tabulator-cell {
-      @apply text-sm text-center font-medium px-2 py-1;
+      font-size: 0.875rem;
+      line-height: 1.25rem;
+      text-align: center;
+      font-weight: 500;
+      padding: 0.25rem 0.5rem;
     }
   </style>
 </head>


### PR DESCRIPTION
## Summary
- remove `base.css` link from `index.html`
- restore original fonts and styling for `index.html`
- unlink `base.css` from `resources/stack-table.html`
- revert fonts/background colors and expand Tailwind `@apply` styles
- validate HTML with `html5validator`

## Testing
- `html5validator index.html resources/stack-table.html`

------
https://chatgpt.com/codex/tasks/task_e_68514560a2d08324938fddb85a5e96f8