### PR TITLE
Fix menu CSS classes to follow GitHub design patterns

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -7,7 +7,7 @@
     <title>Above — Runtime Identity Threat Detection & Response</title>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@200;300;400;500;600;700;800;900&display=swap" rel="stylesheet">
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css" rel="stylesheet">
-    <script type="module" crossorigin src="/slides/assets/index-BTUi7e1W.js"></script>
+    <script type="module" crossorigin src="/slides/assets/index-Bp8GNvBq.js"></script>
     <link rel="stylesheet" crossorigin href="/slides/assets/index-T-hZPjIL.css">
   </head>
   <body>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -606,8 +606,8 @@ const App = () => {
                   className={`menu-item ${currentSlide === index ? 'active' : ''}`}
                   onClick={() => goToSlide(index)}
                 >
-                  <span className="slide-number">{index + 1}</span>
-                  <span className="slide-name">{slide}</span>
+                  <span className="menu-item-number">{index + 1}</span>
+                  <span className="menu-item-title">{slide}</span>
                 </button>
               ))}
             </div>


### PR DESCRIPTION
## 🎯 **Fixes Menu CSS Issues**

**Problem:** Menu was showing random colors (green, blue, orange, purple, teal, pink) instead of GitHub's clean design patterns.

**Root Cause:** JSX was using wrong CSS class names:
- ❌ `.slide-number` and `.slide-name` (undefined classes)
- ✅ `.menu-item-number` and `.menu-item-title` (proper GitHub-styled classes)

**Solution:**
- ✅ Fixed CSS class names to match existing GitHub design system
- ✅ Menu now uses proper GitHub green (#00872b) styling
- ✅ Maintains consistent design patterns across all slides
- ✅ Follows GitHub brand guidelines from https://brand.github.com/

**Testing:**
- ✅ Menu overlay displays with proper GitHub styling
- ✅ Active slide highlighted in GitHub green
- ✅ Hover effects work correctly
- ✅ All navigation functionality preserved

This ensures the presentation follows GitHub's design system consistently.