### PR TITLE
CRITICAL FIX: Repair broken slide rendering

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -7,7 +7,7 @@
     <title>Above — Runtime Identity Threat Detection & Response</title>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@200;300;400;500;600;700;800;900&display=swap" rel="stylesheet">
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css" rel="stylesheet">
-    <script type="module" crossorigin src="/slides/assets/index-wcynwuBs.js"></script>
+    <script type="module" crossorigin src="/slides/assets/index-_GhqxdWG.js"></script>
     <link rel="stylesheet" crossorigin href="/slides/assets/index-eYSprmyb.css">
   </head>
   <body>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -50,7 +50,7 @@ const App = () => {
 
   const renderSlide = () => {
     switch (currentSlide) {
-      case 2:
+      case 1:
         return (
           <div className="slide-container">
             <header className="slide-header">


### PR DESCRIPTION
Fixed the critical issue where slides were not displaying due to case numbers starting from 2 instead of 1. This was causing renderSlide() to return undefined for slide 1, resulting in blank slides.