### PR TITLE
Add styled narrative page

### DIFF
--- a/src/company/pages/CompanyIndex.jsx
+++ b/src/company/pages/CompanyIndex.jsx
@@ -1,10 +1,41 @@
-import React from 'react';
+import React, { useEffect } from 'react';
+import { initializeClarity, clarityEvent } from '../../utils/clarity';
+import VisionHero from '../sections/VisionHero';
+import GoToMarket from '../sections/GoToMarket';
+import PovPlaybook from '../sections/PovPlaybook';
+import MetricsSection from '../sections/MetricsSection';
+import PositioningSection from '../sections/PositioningSection';
+import RoadmapSection from '../sections/RoadmapSection';
+import HypothesesSection from '../sections/HypothesesSection';
+import ValueProofSection from '../sections/ValueProofSection';
+import RisksSection from '../sections/RisksSection';
+import ExecutiveSummarySection from '../sections/ExecutiveSummarySection';
+import '../styles/CompanyIndex.css';
 
 const CompanyIndex = () => {
+  useEffect(() => {
+    try {
+      initializeClarity();
+      clarityEvent('company_narrative_view');
+    } catch (error) {
+      console.warn('Analytics initialization failed:', error);
+    }
+  }, []);
+
   return (
-    <div style={{ padding: '2rem', maxWidth: '800px', margin: '0 auto' }}>
-      <h1>Company</h1>
-      <p>Company page - content coming soon.</p>
+    <div className="company-narrative-container">
+      <VisionHero />
+      <main className="company-narrative-content">
+        <GoToMarket />
+        <PovPlaybook />
+        <MetricsSection />
+        <PositioningSection />
+        <RoadmapSection />
+        <HypothesesSection />
+        <ValueProofSection />
+        <RisksSection />
+        <ExecutiveSummarySection />
+      </main>
     </div>
   );
 };

--- a/src/company/sections/ExecutiveSummarySection.jsx
+++ b/src/company/sections/ExecutiveSummarySection.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import SectionContainer from '../../components/SectionContainer';
+
+const ExecutiveSummarySection = () => (
+  <SectionContainer id="executive-summary" title="9 | EXECUTIVE SUMMARY (TL;DR)">
+    <div>
+      <ul>
+        <li><em>Land fast</em> with phishing prevention &amp; coaching that shows ROI in &lt;14 days.</li>
+        <li><em>Expand</em> by monetizing the <strong>unique browser telemetry</strong> every other control plane lacks.</li>
+        <li><em>Dominate</em> by adding real‑time insider threat prevention, gradually encroaching on legacy CASB / UEBA budgets.</li>
+      </ul>
+      <div className="final-statement">
+        <strong>Above</strong> becomes the lightweight, deploy‑anywhere runtime layer that <strong>starts</strong> where IAM ends and <strong>finishes</strong> what CASB &amp; email security can’t.
+      </div>
+    </div>
+  </SectionContainer>
+);
+
+export default ExecutiveSummarySection;

--- a/src/company/sections/GoToMarket.jsx
+++ b/src/company/sections/GoToMarket.jsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import SectionContainer from '../../components/SectionContainer';
+
+const GoToMarket = () => (
+  <SectionContainer id="go-to-market" title="1 | YEAR‑1 GO‑TO‑MARKET (0‑12 Months)" variant="executive" priority="high">
+    <div>
+      <h3>1.1 How We Sell (Motion)</h3>
+      <table className="narrative-table">
+        <thead>
+          <tr>
+            <th>Stage</th>
+            <th>Channel</th>
+            <th>Champion</th>
+            <th>Commercial Model</th>
+            <th>Critical Risks</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><strong>Land</strong> – 1‑500 seats pilot</td>
+            <td>Direct (founder‑led AE + SE)</td>
+            <td>SecOps Team Lead / Staff Security Engineer</td>
+            <td>Flat pilot fee (or free if under 500 seats)</td>
+            <td>Low signal if no phishing occurs</td>
+          </tr>
+          <tr>
+            <td><strong>Expand</strong> – 500‑5 000 seats</td>
+            <td>Same account team, add CISO exec sponsor</td>
+            <td>CISO / Dir. Identity</td>
+            <td>Annual SaaS (ARR/seat) w/ phishing + telemetry bundle</td>
+            <td>Budget comes from email‑sec – must avoid “yet‑another‑phishing‑tool” bucket</td>
+          </tr>
+          <tr>
+            <td><strong>Scale</strong> – 5 000‑50 000</td>
+            <td>MSSP & VAR co‑sell</td>
+            <td>IR, SOC leadership</td>
+            <td>Tiered seat‑based + volume discount</td>
+            <td>Privacy & data‑residency objections</td>
+          </tr>
+        </tbody>
+      </table>
+      <div className="narrative-hook">
+        <em>"Email gateways catch &lt;40% of initial phish. Everything else starts in the browser – we stop it <strong>and</strong> give you post‑auth forensics the instant you need them."</em>
+      </div>
+
+      <h3>1.2 What We Sell (Packages)</h3>
+      <ol>
+        <li><strong>Starter (PhishGuard)</strong> – real‑time phishing soft‑block & coaching (Chrome Extension only).</li>
+        <li><strong>Growth (PhishGuard + ScopeLens)</strong> – adds full browser telemetry export to SIEM/XDR; timeline & enrichment panels for investigations.</li>
+        <li><strong>Platform (Runtime ITDR)</strong> – unlocks Year‑2 detections (privilege misuse, insider drift) + response policies.</li>
+      </ol>
+      <div className="critical-stance">
+        <strong>Critical stance:</strong> Don’t attempt full insider detections in Year‑1 – “visibility first” avoids promise / delivery gap that kills early deals.
+      </div>
+
+      <h3>1.3 Ideal ICP (Beach‑head)</h3>
+      <ul>
+        <li><strong>Size:</strong> 500‑5 000 employees (fast buy cycles, but material ARR).</li>
+        <li><strong>Profile:</strong> Cloud‑native, Google Workspace / M365, heavy SaaS.</li>
+        <li><strong>Pain triggers:</strong> ‑ Recent AitM / OAuth phish scare ‑ Overworked IR team ‑ Mandate to move toward Zero‑Trust but no budget for Enterprise Browser replacement.</li>
+        <li><strong>Tech stack fit:</strong> Okta or Entra ID, CrowdStrike, Splunk/Chronicle, Proofpoint/Mimecast.</li>
+      </ul>
+    </div>
+  </SectionContainer>
+);
+
+export default GoToMarket;

--- a/src/company/sections/HypothesesSection.jsx
+++ b/src/company/sections/HypothesesSection.jsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import SectionContainer from '../../components/SectionContainer';
+
+const HypothesesSection = () => (
+  <SectionContainer id="hypotheses" title="6 | DEAL‑CRITICAL HYPOTHESES & HOW WE TEST">
+    <div>
+      <table className="narrative-table">
+        <thead>
+          <tr>
+            <th>Hypothesis</th>
+            <th>Evidence Sought in Y1</th>
+            <th>Kill‑Criteria</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Users tolerate coaching interstitials</td>
+            <td>&lt;1 % uninstall rate in pilot</td>
+            <td>&gt;5 % uninstall =&gt; redesign UX</td>
+          </tr>
+          <tr>
+            <td>Browser telemetry materially speeds IR</td>
+            <td>Analysts quote ≥30 % faster RCA</td>
+            <td>&lt;10 % speed‑up =&gt; narrow scope</td>
+          </tr>
+          <tr>
+            <td>Extension delivers enough coverage vs full browser</td>
+            <td>80 % of managed fleet stays on Chrome‑family</td>
+            <td>If customer base shifts to Safari/Firefox &gt;30 %, need cross‑browser port</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </SectionContainer>
+);
+
+export default HypothesesSection;

--- a/src/company/sections/MetricsSection.jsx
+++ b/src/company/sections/MetricsSection.jsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import SectionContainer from '../../components/SectionContainer';
+
+const MetricsSection = () => (
+  <SectionContainer id="metrics" title="3 | METRICS THAT MATTER (LAND → EXPAND)" variant="executive">
+    <div>
+      <table className="narrative-table">
+        <thead>
+          <tr>
+            <th>Dimension</th>
+            <th>KPI</th>
+            <th>Baseline Pain</th>
+            <th>Win Condition</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><strong>Phish Prevention</strong></td>
+            <td>% Consent/OAuth phish blocked pre‑credential</td>
+            <td>Unknown</td>
+            <td>&gt;90 % of events</td>
+          </tr>
+          <tr>
+            <td><strong>User Coaching</strong></td>
+            <td>Override‑after‑coaching rate</td>
+            <td>N/A</td>
+            <td>&lt;2 %</td>
+          </tr>
+          <tr>
+            <td><strong>IR Efficiency</strong></td>
+            <td>Analyst triage time per phish incident</td>
+            <td>45 min</td>
+            <td>&lt;15 min</td>
+          </tr>
+          <tr>
+            <td><strong>Visibility Lift</strong></td>
+            <td>Net‑new SaaS apps surfaced</td>
+            <td>?</td>
+            <td>+20 % in 30 d</td>
+          </tr>
+          <tr>
+            <td><strong>Deployment Friction</strong></td>
+            <td>Support tickets per 1 000 users</td>
+            <td>–</td>
+            <td>&lt;0.5</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </SectionContainer>
+);
+
+export default MetricsSection;

--- a/src/company/sections/PositioningSection.jsx
+++ b/src/company/sections/PositioningSection.jsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import SectionContainer from '../../components/SectionContainer';
+
+const PositioningSection = () => (
+  <SectionContainer id="positioning" title="4 | REPLACE vs ENHANCE – POSITIONING">
+    <div>
+      <table className="narrative-table">
+        <thead>
+          <tr>
+            <th>Tool</th>
+            <th>Our Stance</th>
+            <th>Talk‑Track</th>
+            <th>Risk</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><strong>Secure Email Gateway</strong></td>
+            <td><strong>Enhance</strong></td>
+            <td>“…we catch what slips after the click.”</td>
+            <td>Duplication worries – show pass‑through integration</td>
+          </tr>
+          <tr>
+            <td><strong>CASB / SSE</strong></td>
+            <td><strong>Augment now, muzzle later (Year‑2)</strong></td>
+            <td>“…CASB sees traffic; we see intent in the UI. Eventually we can enforce same policies without PAC files.”</td>
+            <td>Must not appear as direct rip‑and‑replace too early</td>
+          </tr>
+          <tr>
+            <td><strong>Push Security</strong></td>
+            <td><strong>Supersede</strong></td>
+            <td>“Push v2 = us + detection + coaching + SIEM timelines.”</td>
+            <td>Need proof on richer detections</td>
+          </tr>
+          <tr>
+            <td><strong>Enterprise Browser</strong></td>
+            <td><strong>Lightweight alt</strong></td>
+            <td>“Same runtime control without forcing browser swap.”</td>
+            <td>Browser replacement vendors will spread FUD on extension bypass – have answer</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </SectionContainer>
+);
+
+export default PositioningSection;

--- a/src/company/sections/PovPlaybook.jsx
+++ b/src/company/sections/PovPlaybook.jsx
@@ -1,0 +1,111 @@
+import React from 'react';
+import SectionContainer from '../../components/SectionContainer';
+
+const PovPlaybook = () => (
+  <SectionContainer id="pov-playbook" title="2 | YEAR‑1 POV & SUCCESS PLAYBOOK">
+    <div>
+      <h3>2.0 Why So Much Rigor?</h3>
+      <p><em>We get one shot to prove value in less than a monthly sprint. The buyer has five other pilots in flight — we must be the one that actually finishes.</em></p>
+
+      <h3>2.1 PoV Guard‑Rails (3 Weeks Total)</h3>
+      <table className="narrative-table">
+        <thead>
+          <tr>
+            <th>Phase</th>
+            <th>Days</th>
+            <th>Objectives</th>
+            <th>Activities</th>
+            <th>Exit / Evidence</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><strong>Prep</strong></td>
+            <td>−5 → 0</td>
+            <td>Contract / DPIA signed, Admins briefed, Success KPIs frozen</td>
+            <td>30‑min kickoff call, provide force‑install JSON, enable SIEM webhook</td>
+            <td>Work‑back plan agreed, &lt;1 h customer effort</td>
+          </tr>
+          <tr>
+            <td><strong>Week 1 – Instrument</strong></td>
+            <td>1 → 7</td>
+            <td>100 % of pilot fleet covered; no UX regression</td>
+            <td>Push extension, validate health dashboard, daily stand‑up w/ SecOps</td>
+            <td>≥ 90 % agents green, zero perf complaints</td>
+          </tr>
+          <tr>
+            <td><strong>Week 2 – Observe</strong></td>
+            <td>8 → 14</td>
+            <td>Surface “unknown unknowns” + near‑miss phish</td>
+            <td>Passive detections only, risk report, live SIEM enrichment demo</td>
+            <td>≥ 3 true‑positive phish or ≥ 10 consent/OAuth risk events, ≥ 20 % new SaaS surfaced</td>
+          </tr>
+          <tr>
+            <td><strong>Week 3 – Act &amp; Coach</strong></td>
+            <td>15 → 21</td>
+            <td>Prove user coaching &amp; SOC efficiency</td>
+            <td>Flip to soft‑block, measure override rate, IR drill with timeline, exec read‑out</td>
+            <td>&lt;1 % override, 2× faster triage, signed business‑case deck</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <h3>2.2 Success KPIs &amp; Pass‑Fail Gates</h3>
+      <table className="narrative-table">
+        <thead>
+          <tr>
+            <th>KPI</th>
+            <th>Pass Target</th>
+            <th>Fail Trigger</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Phish / consent phish blocked pre‑credential</td>
+            <td>&gt; 90 % of observed events</td>
+            <td>&lt; 70 %</td>
+          </tr>
+          <tr>
+            <td>Unknown SaaS discovery delta</td>
+            <td>&ge; 20 % increase</td>
+            <td>&lt; 10 %</td>
+          </tr>
+          <tr>
+            <td>User override rate after coaching</td>
+            <td>&lt; 2 %</td>
+            <td>&ge; 5 %</td>
+          </tr>
+          <tr>
+            <td>Analyst triage time reduction</td>
+            <td>&ge; 30 % faster</td>
+            <td>&lt; 10 %</td>
+          </tr>
+          <tr>
+            <td>Deployment effort (customer hours)</td>
+            <td>&le; 4 h total</td>
+            <td>&gt; 8 h</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <h3>2.3 If No Real Attacks Occur</h3>
+      <ol>
+        <li><strong>Near‑Miss Ledger</strong> – auto‑generate annotated timeline of blocked look‑alike domains, expired certificates, abnormal OAuth scopes.</li>
+        <li><strong>Visibility Wins Report</strong> – quantified SaaS &amp; extension inventory delta delivered as PDF plus raw CSV for SIEM.</li>
+        <li><strong>Forensic Drill</strong> – SOC re‑opens a closed phish ticket; runs side‑by‑side with/without Above telemetry.</li>
+        <li><strong>Red‑Team Voucher</strong> – post‑purchase commitment: <em>if</em> internal red‑team bypasses Above we credit 1 mo licence.</li>
+      </ol>
+
+      <h3>2.4 Set‑up Checklist (Shared with Buyer)</h3>
+      <ul>
+        <li>Stakeholder map (CISO, SecOps lead, IT, Privacy Counsel)</li>
+        <li>Definition of “pilot success” signed (KPIs &amp; thresholds)</li>
+        <li>Browser versions &gt; v116 Chrome / Edge confirmed</li>
+        <li>SIEM endpoint / token supplied</li>
+        <li>Slack or Teams channel for daily comms</li>
+      </ul>
+    </div>
+  </SectionContainer>
+);
+
+export default PovPlaybook;

--- a/src/company/sections/RisksSection.jsx
+++ b/src/company/sections/RisksSection.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import SectionContainer from '../../components/SectionContainer';
+
+const RisksSection = () => (
+  <SectionContainer id="risks" title="8 | CRITICAL RISKS & COUNTER‑MEASURES">
+    <div>
+      <ul>
+        <li><strong>Extension removal / evasion</strong> – Detect uninstall, auto‑re‑enroll via MDM, raise IdP webhook to force step‑up auth.</li>
+        <li><strong>Privacy objections</strong> – Provide on‑device redaction, PCI/PII tag drop, and EU data‑center option; publish DPIA template.</li>
+        <li><strong>‘Yet another console’ fatigue</strong> – Ship Splunk / Sentinel apps Day‑1; console optional.</li>
+      </ul>
+    </div>
+  </SectionContainer>
+);
+
+export default RisksSection;

--- a/src/company/sections/RoadmapSection.jsx
+++ b/src/company/sections/RoadmapSection.jsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import SectionContainer from '../../components/SectionContainer';
+
+const RoadmapSection = () => (
+  <SectionContainer id="roadmap" title="5 | YEAR‑2 EXPANSION ROADMAP (12‑24 Months)">
+    <div>
+      <table className="narrative-table">
+        <thead>
+          <tr>
+            <th>Q</th>
+            <th>Capability</th>
+            <th>New Revenue Lever</th>
+            <th>Hypothesis to Prove</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><strong>Q1‑Q2</strong></td>
+            <td>Insider heat‑map (behavioral drift scoring)</td>
+            <td>Add‑on per‑seat fee</td>
+            <td>Browser telemetry + ML = earlier insider signal than DTEX</td>
+          </tr>
+          <tr>
+            <td><strong>Q2‑Q3</strong></td>
+            <td>Real‑time policy actions (block mass export, rogue role change)</td>
+            <td>“Runtime DLP Lite” module</td>
+            <td>Customers will pay to prevent insider misuse, not just observe</td>
+          </tr>
+          <tr>
+            <td><strong>Q3‑Q4</strong></td>
+            <td>API tie‑ins to ZTNA / IdP for session kill, step‑up auth</td>
+            <td>Enterprise tier / workflow credits</td>
+            <td>Orchestrated response drives stickiness and upsell</td>
+          </tr>
+          <tr>
+            <td><strong>Q4</strong></td>
+            <td>BYOD lightweight agent (Edge + unmanaged Chrome)</td>
+            <td>Opens EDU & contractor‑heavy verticals</td>
+            <td>Privacy gates solvable with FIDO attestation</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <h3>Year‑2 ICP Layer‑Cake</h3>
+      <ol>
+        <li><strong>Existing PhishGuard customers</strong> – upsell Runtime ITDR.</li>
+        <li><strong>IRM / Insider‑Risk programs</strong> in financial / healthcare orgs.</li>
+        <li><strong>CASB refresh cycles</strong> where Netskope / Skyhigh replacement is planned – sell as faster/cheaper alternative.</li>
+      </ol>
+    </div>
+  </SectionContainer>
+);
+
+export default RoadmapSection;

--- a/src/company/sections/ValueProofSection.jsx
+++ b/src/company/sections/ValueProofSection.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import SectionContainer from '../../components/SectionContainer';
+
+const ValueProofSection = () => (
+  <SectionContainer id="value-proof" title="7 | IF NO ATTACKS DURING POV – PROVING VALUE">
+    <div>
+      <ol>
+        <li><strong>Near‑miss Evidence</strong> – Show flagged consent pages, password‑reuse prompts, and blocklist hits from open‑source phish IOCs.</li>
+        <li><strong>Visibility Delta</strong> – Quantify unknown SaaS, risky extensions, weak MFA scores for each user – give risk report.</li>
+        <li><strong>Investigation Drill</strong> – Re‑play a historic incident with and without our timeline; have analyst live‑compare speed.</li>
+        <li><strong>Red‑Team Voucher</strong> – Offer post‑sale internal phish simulation voucher to prove stop‑rate (paid by us if miss KPI).</li>
+      </ol>
+      <div className="blunt-message">
+        <em>"If in 14 days we don't surface anything you find useful, we deserve to lose."</em>
+      </div>
+    </div>
+  </SectionContainer>
+);
+
+export default ValueProofSection;

--- a/src/company/sections/VisionHero.jsx
+++ b/src/company/sections/VisionHero.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+const VisionHero = () => (
+  <header className="company-hero">
+    <h1 className="company-hero-title">Above Strategic Narrative</h1>
+    <p className="company-hero-subtitle">Two‑Year Strategic Narrative &amp; Execution Plan</p>
+    <p className="vision-statement">
+      <em>Become the browser‑native control plane that sees and stops what every other security tool misses – from sophisticated phishing to gray‑area insider misuse – without changing how users work.</em>
+    </p>
+  </header>
+);
+
+export default VisionHero;

--- a/src/company/styles/CompanyIndex.css
+++ b/src/company/styles/CompanyIndex.css
@@ -1,0 +1,90 @@
+/* CompanyIndex.css - Styled narrative page using PhishingDetection patterns */
+@import '../../styles/base/variables.css';
+@import '../../styles/components/section-headers.css';
+@import '../../styles/components/content-groups.css';
+
+.company-narrative-container {
+  background: var(--bg-primary);
+  color: var(--text-primary);
+  font-family: var(--font-brand-body);
+  min-height: 100vh;
+}
+
+.company-narrative-content {
+  max-width: 1000px;
+  margin: 0 auto;
+  padding: var(--spacing-4xl) var(--spacing-3xl);
+}
+
+.company-hero {
+  position: relative;
+  text-align: center;
+  padding: var(--spacing-4xl) var(--spacing-2xl);
+  border: 1px solid var(--border-secondary);
+  background: var(--surface-primary);
+  border-radius: var(--radius-xl);
+  box-shadow: var(--shadow-lg);
+  margin-bottom: var(--spacing-4xl);
+}
+
+.company-hero-title {
+  font-size: var(--text-4xl);
+  font-weight: var(--weight-bold);
+  margin-bottom: var(--spacing-lg);
+}
+
+.company-hero-subtitle {
+  font-size: var(--text-lg);
+  color: var(--text-secondary);
+  margin-bottom: var(--spacing-xl);
+}
+
+.vision-statement {
+  font-size: var(--text-xl);
+  line-height: var(--leading-loose);
+  font-style: italic;
+  max-width: 800px;
+  margin: 0 auto;
+  color: var(--text-primary);
+}
+
+.narrative-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: var(--spacing-xl) 0;
+}
+
+.narrative-table th,
+.narrative-table td {
+  padding: var(--spacing-sm);
+  border: 1px solid var(--border-secondary);
+  text-align: left;
+  font-size: var(--text-sm);
+}
+
+.narrative-table th {
+  background: var(--surface-secondary);
+  font-weight: var(--weight-semibold);
+}
+
+.narrative-hook,
+.critical-stance,
+.blunt-message {
+  background: var(--bg-secondary);
+  border-left: 4px solid var(--brand-primary);
+  border-radius: 0 var(--radius-md) var(--radius-md) 0;
+  padding: var(--spacing-md);
+  margin: var(--spacing-lg) 0;
+  font-size: var(--text-sm);
+  line-height: var(--leading-relaxed);
+}
+
+.final-statement {
+  background: var(--bg-dark);
+  color: var(--text-inverse);
+  padding: var(--spacing-xl);
+  border-radius: var(--radius-lg);
+  margin-top: var(--spacing-xl);
+  text-align: center;
+  font-size: var(--text-md);
+}


### PR DESCRIPTION
## Summary
- restyle CompanyIndex with PhishingDetection design
- add narrative sections using markdown content
- keep styles self-contained in new CSS
- provide analytics on page load

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_685864b1c6708324ba51efcb3959ef26